### PR TITLE
feat: sort by boost/allocation

### DIFF
--- a/.project-mainnet-cid
+++ b/.project-mainnet-cid
@@ -1,1 +1,1 @@
-QmQbSumWfjgEfrPGsnNGAhq7SyXDjxKQCXLSjRiPpgFktd
+QmQqqmwwaBben8ncfHo3DMnDxyWFk5QcEdTmbevzKj7DBd

--- a/.project-testnet-cid
+++ b/.project-testnet-cid
@@ -1,1 +1,1 @@
-QmYQyLaWxwrFW4qwSFvzSvd1iGzA4hiiZijoHE8wqiDKBv
+QmXohjyZ2WzaAo6irrctD1w8hVZ95RkCR9GbSKP7NeM8PK

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.7.0",
     "@subql/common-ethereum": "^4.5.3",
-    "@subql/contract-sdk": "^1.5.0",
+    "@subql/contract-sdk": "^1.9.0-1",
     "@subql/types-ethereum": "^3.5.0",
     "@types/pino": "^7.0.5",
     "@types/validator": "latest",

--- a/project-mainnet.yaml
+++ b/project-mainnet.yaml
@@ -133,6 +133,11 @@ dataSources:
           filter:
             topics:
               - DelegationAdded(address indexed source, address indexed runner, uint256 amount)
+        - handler: handleAddDelegation
+          kind: ethereum/LogHandler
+          filter:
+            topics:
+              - DelegationAdded2(address indexed source, address indexed runner, uint256 amount, bool instant)
         - handler: handleRemoveDelegation
           kind: ethereum/LogHandler
           filter:

--- a/project-testnet.yaml
+++ b/project-testnet.yaml
@@ -136,6 +136,11 @@ dataSources:
           filter:
             topics:
               - DelegationAdded(address indexed source, address indexed runner, uint256 amount)
+        - handler: handleAddDelegation
+          kind: ethereum/LogHandler
+          filter:
+            topics:
+              - DelegationAdded2(address indexed source, address indexed runner, uint256 amount, bool instant)
         - handler: handleRemoveDelegation
           kind: ethereum/LogHandler
           filter:

--- a/schema.graphql
+++ b/schema.graphql
@@ -61,6 +61,7 @@ type Project @entity {
   totalReward: BigInt!
   totalBoost: BigInt!
   totalAllocation: BigInt!
+  boostAllocationRatio: BigInt!
 
   deployments: [Deployment] @derivedFrom(field: "project")
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -59,6 +59,8 @@ type Project @entity {
   updatedTimestamp: Date!
   createdTimestamp: Date!
   totalReward: BigInt!
+  totalBoost: BigInt!
+  totalAllocation: BigInt!
 
   deployments: [Deployment] @derivedFrom(field: "project")
 

--- a/src/mappings/projectRegistry.ts
+++ b/src/mappings/projectRegistry.ts
@@ -63,6 +63,8 @@ export async function handleProjectCreated(
     // note that project metadata is pure CID string without prefix
     metadata: projectMetadata,
     totalReward: BigInt(0),
+    totalBoost: BigInt(0),
+    totalAllocation: BigInt(0),
     deploymentId: bytesToIpfsCid(deploymentId),
     deploymentMetadata: bytesToIpfsCid(deploymentMetadata),
     updatedTimestamp: biToDate(event.block.timestamp),

--- a/src/mappings/projectRegistry.ts
+++ b/src/mappings/projectRegistry.ts
@@ -65,6 +65,7 @@ export async function handleProjectCreated(
     totalReward: BigInt(0),
     totalBoost: BigInt(0),
     totalAllocation: BigInt(0),
+    boostAllocationRatio: BigInt(0),
     deploymentId: bytesToIpfsCid(deploymentId),
     deploymentMetadata: bytesToIpfsCid(deploymentMetadata),
     updatedTimestamp: biToDate(event.block.timestamp),

--- a/src/mappings/rewardsBooster.ts
+++ b/src/mappings/rewardsBooster.ts
@@ -24,7 +24,7 @@ import {
   ServiceAgreement,
   StateChannel,
 } from '../types';
-import { biToDate, bytesToIpfsCid } from './utils';
+import { biToDate, bytesToIpfsCid, handleProjectTotalBoost } from './utils';
 import { getCurrentEra } from './eraManager';
 import { BigNumber } from 'ethers';
 import { upsertEraIndexerDeploymentApy } from './rewardsDistributor';
@@ -63,7 +63,7 @@ export async function handleDeploymentBoosterAdded(
   let saveProject = false;
   if (project) {
     saveProject = true;
-    project.totalBoost += amountAdded.toBigInt();
+    handleProjectTotalBoost(project, amountAdded.toBigInt());
   }
 
   if (!project && preboostedCids.includes(deploymentId)) {
@@ -79,6 +79,7 @@ export async function handleDeploymentBoosterAdded(
       totalReward: BigInt(0),
       totalBoost: BigInt(0),
       totalAllocation: BigInt(0),
+      boostAllocationRatio: BigInt(0),
     });
   }
   assert(project, `Project ${deployment.projectId} not found`);
@@ -174,7 +175,8 @@ export async function handleDeploymentBoosterRemoved(
     summary.updateAt = biToDate(event.block.timestamp);
   }
 
-  project.totalBoost = project.totalBoost - amountRemoved.toBigInt();
+  handleProjectTotalBoost(project, -amountRemoved.toBigInt());
+
   await project.save();
   await summary.save();
 }

--- a/src/mappings/staking.ts
+++ b/src/mappings/staking.ts
@@ -129,7 +129,12 @@ export async function handleAddDelegation(
       createdBlock: event.blockNumber,
     });
   } else {
-    delegation.amount = await upsertEraValue(delegation.amount, amountBn);
+    delegation.amount = await upsertEraValue(
+      delegation.amount,
+      amountBn,
+      'add',
+      applyInstantly
+    );
   }
 
   if (BigInt.fromJSONType(delegation.amount.valueAfter) > BigInt(0)) {
@@ -881,7 +886,8 @@ async function updateEraStakeAdd(
     delegator,
     nextEraId,
     nextEraIdx,
-    amountBn
+    amountBn,
+    instant
   );
 }
 
@@ -909,7 +915,8 @@ async function updateEraStake(
   delegator: string,
   eraId: string,
   eraIdx: number,
-  amountBn: bigint
+  amountBn: bigint,
+  instant?: boolean
 ) {
   let eraStake = await EraStake.get(eraStakeId);
   if (!eraStake) {
@@ -924,7 +931,7 @@ async function updateEraStake(
       delegatorId: delegator,
       eraId,
       eraIdx,
-      stake: lastStakeAmountBn + amountBn,
+      stake: instant ? lastStakeAmountBn : lastStakeAmountBn + amountBn,
     });
   } else {
     eraStake.stake += amountBn;

--- a/src/mappings/staking.ts
+++ b/src/mappings/staking.ts
@@ -92,7 +92,6 @@ export async function handleAddDelegation(
   logger.info('handleAddDelegation');
   assert(event.args, 'No event args');
 
-  // const { source, runner, amount } = event.args;
   const { source, runner, amount, instant } = event.args;
   const id = getDelegationId(source, runner);
 

--- a/src/mappings/staking.ts
+++ b/src/mappings/staking.ts
@@ -549,7 +549,8 @@ async function updateIndexerStakeSummaryAdded(
     currEraIdx,
     nextEraId,
     nextEraIdx,
-    indexerStakeSummary
+    indexerStakeSummary,
+    instant
   );
 
   // update EraStake
@@ -561,7 +562,8 @@ async function updateIndexerStakeSummaryAdded(
     currEraIdx,
     nextEraId,
     nextEraIdx,
-    amountBn
+    amountBn,
+    instant
   );
 
   // update IndexerStake for all indexers, sum by era
@@ -571,7 +573,8 @@ async function updateIndexerStakeSummaryAdded(
     currEraIdx,
     nextEraId,
     nextEraIdx,
-    allIndexerStakeSummary
+    allIndexerStakeSummary,
+    instant
   );
 }
 
@@ -582,9 +585,10 @@ async function updateIndexerStakeAdded(
   currEraIdx: number,
   nextEraId: string,
   nextEraIdx: number,
-  indexerStakeSummary: IndexerStakeSummary
+  indexerStakeSummary: IndexerStakeSummary,
+  instant: boolean
 ) {
-  if (isFirstStake) {
+  if (isFirstStake || instant) {
     await IndexerStake.create({
       id: `${indexer}:${currEraId}`,
       indexerId: indexer,
@@ -612,9 +616,10 @@ async function updateIndexerStakeAddedSumByEra(
   currEraIdx: number,
   nextEraId: string,
   nextEraIdx: number,
-  allIndexerStakeSummary: IndexerStakeSummary
+  allIndexerStakeSummary: IndexerStakeSummary,
+  instant: boolean
 ) {
-  if (isFirstStake) {
+  if (isFirstStake || instant) {
     await IndexerStake.create({
       id: currEraId,
       indexerId: '0x00',
@@ -855,9 +860,10 @@ async function updateEraStakeAdd(
   currEraIdx: number,
   nextEraId: string,
   nextEraIdx: number,
-  amountBn: bigint
+  amountBn: bigint,
+  instant: boolean
 ) {
-  if (isFirstStake) {
+  if (isFirstStake || instant) {
     const currEraStakeId = `${indexer}:${delegator}:${currEraId}`;
     await updateEraStake(
       currEraStakeId,

--- a/src/mappings/staking.ts
+++ b/src/mappings/staking.ts
@@ -98,7 +98,7 @@ export async function handleAddDelegation(
   const amountBn = amount.toBigInt();
   let delegation = await Delegation.get(id);
   const selfStake = source === runner;
-  const applyInstantly = runner === source && !delegation;
+  const applyInstantly = (runner === source && !delegation) || instant;
   if (!selfStake) {
     await updateDelegatorDelegation(source, amountBn, 'add', applyInstantly);
   }
@@ -140,7 +140,7 @@ export async function handleAddDelegation(
   await updateIndexerCapacity(runner, event);
   await updateMaxUnstakeAmount(runner, event);
   await updateIndexerStakeSummaryAdded(event);
-  if (applyInstantly || instant) {
+  if (applyInstantly) {
     await addToEraDelegation(
       delegation.amount.era,
       runner,

--- a/src/mappings/staking.ts
+++ b/src/mappings/staking.ts
@@ -87,18 +87,13 @@ async function createOrUpdateWithdrawl({
 }
 
 export async function handleAddDelegation(
-  event: EthereumLog<
-    DelegationAddedEvent['args'] | DelegationAdded2Event['args']
-  >
+  event: EthereumLog<DelegationAdded2Event['args']>
 ): Promise<void> {
   logger.info('handleAddDelegation');
   assert(event.args, 'No event args');
 
   // const { source, runner, amount } = event.args;
-  const { source, runner, amount, instant } = parseCompatibleDelegationArgs(
-    event.args
-  );
-
+  const { source, runner, amount, instant } = event.args;
   const id = getDelegationId(source, runner);
 
   const amountBn = amount.toBigInt();
@@ -212,24 +207,6 @@ export async function handleRemoveDelegation(
     source,
     amount.toBigInt()
   );
-}
-
-type CompatibleDelegationAddedArgs = {
-  source: string;
-  runner: string;
-  amount: BigNumber;
-  instant: boolean;
-};
-
-function parseCompatibleDelegationArgs(
-  args: DelegationAddedEvent['args'] | DelegationAdded2Event['args']
-): CompatibleDelegationAddedArgs {
-  return {
-    source: args.source,
-    runner: args.runner,
-    amount: args.amount,
-    instant: 'instant' in args ? args.instant : false,
-  };
 }
 
 async function addToEraDelegation(
@@ -518,14 +495,10 @@ export async function handleWithdrawCancelled(
 }
 
 async function updateIndexerStakeSummaryAdded(
-  event: EthereumLog<
-    DelegationAddedEvent['args'] | DelegationAdded2Event['args']
-  >
+  event: EthereumLog<DelegationAdded2Event['args']>
 ): Promise<void> {
   assert(event.args, 'No event args');
-  const { source, runner, amount, instant } = parseCompatibleDelegationArgs(
-    event.args
-  );
+  const { source, runner, amount, instant } = event.args;
   const amountBn = amount.toBigInt();
 
   const currEraIdx = await getCurrentEra();

--- a/src/mappings/stakingAllocation.ts
+++ b/src/mappings/stakingAllocation.ts
@@ -15,7 +15,11 @@ import {
   IndexerLatestAllocationOverflow,
   Project,
 } from '../types';
-import { biToDate, bytesToIpfsCid } from './utils';
+import {
+  biToDate,
+  bytesToIpfsCid,
+  handleProjectTotalAllocation,
+} from './utils';
 import { getCurrentEra } from './eraManager';
 
 export async function handleStakeAllocationAdded(
@@ -81,7 +85,7 @@ export async function handleStakeAllocationAdded(
     await apy.save();
   }
 
-  project.totalAllocation += amountAdded.toBigInt();
+  handleProjectTotalAllocation(project, amountAdded.toBigInt());
   await project.save();
 }
 
@@ -150,7 +154,7 @@ export async function handleStakeAllocationRemoved(
     await apy.save();
   }
 
-  project.totalAllocation -= amountRemoved.toBigInt();
+  handleProjectTotalAllocation(project, -amountRemoved.toBigInt());
   await project.save();
 }
 

--- a/src/mappings/stakingAllocation.ts
+++ b/src/mappings/stakingAllocation.ts
@@ -80,6 +80,9 @@ export async function handleStakeAllocationAdded(
     apy.apyCalcAllocationRecordAt = biToDate(event.block.timestamp);
     await apy.save();
   }
+
+  project.totalAllocation += amountAdded.toBigInt();
+  await project.save();
 }
 
 export async function handleStakeAllocationRemoved(
@@ -146,6 +149,9 @@ export async function handleStakeAllocationRemoved(
     apy.apyCalcAllocationRecordAt = biToDate(event.block.timestamp);
     await apy.save();
   }
+
+  project.totalAllocation -= amountRemoved.toBigInt();
+  await project.save();
 }
 
 export async function handleOverAllocationStarted(

--- a/src/mappings/utils/helpers.ts
+++ b/src/mappings/utils/helpers.ts
@@ -8,7 +8,7 @@ import { EthereumLog } from '@subql/types-ethereum';
 import bs58 from 'bs58';
 
 import assert from 'assert';
-import { AirdropAmount, Exception, JSONBigInt } from '../../types';
+import { AirdropAmount, Exception, JSONBigInt, Project } from '../../types';
 import { BigNumberish } from 'ethers';
 import { PER_QUINTILL } from './constants';
 
@@ -47,7 +47,6 @@ declare global {
     fromJSONType(value: unknown): bigint;
   }
 }
-
 
 BigInt.prototype.toJSONType = function () {
   return {
@@ -197,4 +196,28 @@ export function calcApy(reward: bigint, stake: bigint): bigint {
   }
 
   return (((reward * PER_QUINTILL) / BigInt(7)) * BigInt(365)) / stake;
+}
+
+export function handleProjectTotalBoost(
+  project: Project,
+  totalBoostDelta: bigint
+) {
+  project.totalBoost += totalBoostDelta;
+  if (project.totalAllocation > 0) {
+    const precision = BigNumber.from(10).pow(18).toBigInt();
+    project.boostAllocationRatio =
+      (project.totalBoost * precision) / project.totalAllocation;
+  }
+}
+
+export function handleProjectTotalAllocation(
+  project: Project,
+  totalAllocationDelta: bigint
+) {
+  project.totalAllocation += totalAllocationDelta;
+  if (project.totalAllocation > 0) {
+    const precision = BigNumber.from(10).pow(18).toBigInt();
+    project.boostAllocationRatio =
+      (project.totalBoost * precision) / project.totalAllocation;
+  }
 }

--- a/src/mappings/utils/updateDbFunctions.ts
+++ b/src/mappings/utils/updateDbFunctions.ts
@@ -340,6 +340,8 @@ export async function updateTotalLock(
     ? BigNumber.from(0)
     : BigNumber.from(amount);
 
+  const { instant } = event.args || {};
+
   if (!totalLock) {
     totalLock = TotalLock.create({
       id: totalLockID,
@@ -359,12 +361,14 @@ export async function updateTotalLock(
     totalLock.totalStake = await upsertEraValue(
       totalLock.totalStake,
       updatedStakeAmount.toBigInt(),
-      operation
+      operation,
+      instant
     );
     totalLock.totalDelegation = await upsertEraValue(
       totalLock.totalDelegation,
       updatedDelegateAmount.toBigInt(),
-      operation
+      operation,
+      instant
     );
     totalLock.lastEvent = `updateTotalLock - ${event.transactionHash}`;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2589,10 +2589,10 @@
     semver "^7.6.3"
     update-notifier "^5.1.0"
 
-"@subql/contract-sdk@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@subql/contract-sdk/-/contract-sdk-1.5.0.tgz#bca32ab92b32cef8a0c37bf0c5b550661542c614"
-  integrity sha512-x4bVew9GNJpmmOf2hYirgivanDPscSnRRvBMZ2v09kk9oixLzYRM5vn/Bg64u6PIu9/QEVS659GT136IKMXRDA==
+"@subql/contract-sdk@^1.9.0-1":
+  version "1.9.0-1"
+  resolved "https://registry.yarnpkg.com/@subql/contract-sdk/-/contract-sdk-1.9.0-1.tgz#010f4efcae257ac353d45ee5ea56b1b125e75e13"
+  integrity sha512-1jimoHU46UuCajLZ8+VeTdUFidyTBJqyPClhCn46YpLb9ye+SBJDnEWpLi6NGJzNhkfh3wyIrwes9wf/Bo8nIw==
 
 "@subql/types-algorand@3.3.0":
   version "3.3.0"


### PR DESCRIPTION
* add handler for `instant` delegation.
* add `totalBoost` and `totalAllocation` in `Project Entity` for sort efficiency.
    * when `DeploymentBoosterSummary` changed, update `Project.totalBoost`.
    * when `IndexerAllocationSummary` changed, update `Project.totalAllocation`.